### PR TITLE
Create App Insights create dir before starting

### DIFF
--- a/src/main/modules/appinsights/index.ts
+++ b/src/main/modules/appinsights/index.ts
@@ -13,11 +13,10 @@ export class AppInsights {
     if (config.get('appInsights.instrumentationKey')) {
       this.logger.info('Starting App Insights');
 
-      appInsights.setup(config.get('appInsights.instrumentationKey'))
-        .setDistributedTracingMode(appInsights.DistributedTracingModes.AI_AND_W3C)
+      appInsights.setup(config.get<string>('appInsights.instrumentationKey'))
         .setSendLiveMetrics(true)
         .setAutoCollectConsole(true, true)
-        .setAutoCollectExceptions(true)
+        .setUseDiskRetryCaching(false)
         .start();
 
       appInsights.defaultClient.context.tags[appInsights.defaultClient.context.keys.cloudRole] = 'lau-frontend';

--- a/src/main/modules/appinsights/index.ts
+++ b/src/main/modules/appinsights/index.ts
@@ -2,6 +2,10 @@ import {LoggerInstance} from 'winston';
 const {Logger} = require('@hmcts/nodejs-logging');
 
 import config from 'config';
+import Sender from 'applicationinsights/out/Library/Sender';
+import * as os from 'os';
+import path from 'path';
+import fs from 'fs';
 
 const appInsights = require('applicationinsights');
 
@@ -11,16 +15,26 @@ export class AppInsights {
 
   enable(): void {
     if (config.get('appInsights.instrumentationKey')) {
+      this.createTempDir();
+
       this.logger.info('Starting App Insights');
 
       appInsights.setup(config.get<string>('appInsights.instrumentationKey'))
         .setSendLiveMetrics(true)
         .setAutoCollectConsole(true, true)
-        .setUseDiskRetryCaching(false)
         .start();
 
       appInsights.defaultClient.context.tags[appInsights.defaultClient.context.keys.cloudRole] = 'lau-frontend';
       appInsights.defaultClient.trackTrace({message: 'App insights activated'});
+    }
+  }
+
+  private createTempDir(): void {
+    const tempDir = path.join(os.tmpdir(), Sender.TEMPDIR_PREFIX + config.get('appInsights.instrumentationKey'));
+
+    if (!fs.existsSync(tempDir)) {
+      this.logger.info('Creating App Insights temp dir');
+      fs.mkdirSync(tempDir);
     }
   }
 


### PR DESCRIPTION
The disk retry cache feature uses a temp dir. This PR create that dir before starting app insights to prevent ENOENT errors.