### PR TITLE
Disable security scan

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -19,7 +19,7 @@ withNightlyPipeline(type, product, component) {
   enableMutationTest();
   enableSlackNotifications('#lau-builds')
   enableFortifyScan()
-  enableSecurityScan()
+  //enableSecurityScan()
 
   after('fortify-scan') {
       steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/Fortify Scan/**/*'


### PR DESCRIPTION
Temporarily disable security scan until platform wide issues have been resolved