### PR TITLE
LAU-376 Upgrade Cookie Manager V1 (under toggle)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lau-frontend",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "private": true,
   "engines": {
     "node": ">=14.16.0"
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "@hmcts/cookie-manager": "^0.0.5",
+    "@hmcts/cookie-manager-v1": "npm:@hmcts/cookie-manager@^1.0.0",
     "@hmcts/info-provider": "^1.0.0",
     "@hmcts/nodejs-healthcheck": "^1.7.0",
     "@hmcts/nodejs-logging": "^3.0.4",

--- a/src/main/assets/js/cookie-v1.ts
+++ b/src/main/assets/js/cookie-v1.ts
@@ -1,0 +1,69 @@
+import cookieManager from '@hmcts/cookie-manager-v1';
+
+declare global {
+  interface Window {
+    dataLayer: Record<string, unknown>[];
+    dtrum: DtrumApi;
+  }
+}
+
+interface DtrumApi {
+  enable(): void;
+  enableSessionReplay(): void;
+  disable(): void;
+  disableSessionReplay(): void;
+}
+
+export function initCookieManagerV1(): void {
+  console.log('Initializing Cookie Manager V1');
+
+  cookieManager.on('UserPreferencesLoaded', (preferences: unknown) => {
+    const dataLayer = window.dataLayer || [];
+    dataLayer.push({'event': 'Cookie Preferences', 'cookiePreferences': preferences});
+  });
+
+  cookieManager.on('UserPreferencesSaved', (preferences: {apm: string}) => {
+    const dataLayer = window.dataLayer || [];
+    const dtrum = window.dtrum;
+
+    dataLayer.push({'event': 'Cookie Preferences', 'cookiePreferences': preferences});
+
+    if(dtrum !== undefined) {
+      if(preferences.apm === 'on') {
+        dtrum.enable();
+        dtrum.enableSessionReplay();
+      } else {
+        dtrum.disableSessionReplay();
+        dtrum.disable();
+      }
+    }
+  });
+
+  cookieManager.on('PreferenceFormSubmitted', () => {
+    const message: HTMLInputElement = document.querySelector('.cookie-preference-success');
+    message.style.display = 'block';
+    document.body.scrollTop = 0; // For Safari
+    document.documentElement.scrollTop = 0; // For Chrome, Firefox, IE and Opera
+  });
+
+  cookieManager.init({
+    userPreferences: {
+      cookieName: 'lau-cookie-preferences',
+    },
+    cookieManifest: [
+      {
+        categoryName: 'essential',
+        optional: false,
+        cookies: ['lau-cookie-preferences', 'lau-session', 'Idam.Session', 'seen_cookie_message', '_oauth2_proxy'],
+      },
+      {
+        categoryName: 'analytics',
+        cookies: ['_ga', '_gid', '_gat_UA-'],
+      },
+      {
+        categoryName: 'apm',
+        cookies: ['dtCookie', 'dtLatC', 'dtPC', 'dtSa', 'rxVisitor', 'rxvt'],
+      },
+    ],
+  });
+}

--- a/src/main/assets/js/cookie.ts
+++ b/src/main/assets/js/cookie.ts
@@ -1,81 +1,6 @@
 // @ts-ignore HMTCS Cookie Manager is not typed.
 import * as cookieManager from '@hmcts/cookie-manager';
-import { qs } from './selectors';
-
-const cookieBanner = qs('#cm-cookie-banner');
-const cookieBannerDecision: HTMLInputElement = cookieBanner?.querySelector('.govuk-cookie-banner__decision');
-const cookieBannerConfirmation: HTMLInputElement = cookieBanner?.querySelector('.govuk-cookie-banner__confirmation');
-
-function cookieBannerAccept() {
-  const confirmationMessage = cookieBannerConfirmation?.querySelector('p') as HTMLInputElement;
-  confirmationMessage.innerHTML = 'You’ve accepted additional cookies. ' + confirmationMessage.innerHTML;
-}
-
-function cookieBannerReject() {
-  const confirmationMessage = cookieBannerConfirmation?.querySelector('p') as HTMLInputElement;
-  confirmationMessage.innerHTML = 'You’ve rejected additional cookies. ' + confirmationMessage.innerHTML;
-}
-
-function cookieBannerSaved() {
-  cookieBannerDecision.hidden = true;
-  cookieBannerConfirmation.hidden = false;
-}
-
-function preferenceFormSaved() {
-  const message = qs('.cookie-preference-success') as HTMLInputElement;
-  message.style.display = 'block';
-  document.body.scrollTop = 0; // For Safari
-  document.documentElement.scrollTop = 0; // For Chrome, Firefox, IE and Opera
-}
-
-// @ts-ignore
-function cookiePreferencesUpdated(cookieStatus) {
-  const dataLayer = window.dataLayer || [];
-  const dtrum = window.dtrum;
-
-  dataLayer.push({ event: 'Cookie Preferences', cookiePreferences: cookieStatus });
-
-  if (dtrum !== undefined) {
-    if (cookieStatus.apm === 'on') {
-      dtrum.enable();
-      dtrum.enableSessionReplay();
-    } else {
-      dtrum.disableSessionReplay();
-      dtrum.disable();
-    }
-  }
-}
-
-cookieManager.init({
-  'user-preference-cookie-name': 'lau-cookie-preferences',
-  'user-preference-saved-callback': cookiePreferencesUpdated,
-  'preference-form-id': 'cm-preference-form',
-  'preference-form-saved-callback': preferenceFormSaved,
-  'set-checkboxes-in-preference-form': true,
-  'cookie-banner-id': 'cm-cookie-banner',
-  'cookie-banner-visible-on-page-with-preference-form': false,
-  'cookie-banner-reject-callback': cookieBannerReject,
-  'cookie-banner-accept-callback': cookieBannerAccept,
-  'cookie-banner-saved-callback': cookieBannerSaved,
-  'cookie-banner-auto-hide': false,
-  'cookie-manifest': [
-    {
-      'category-name': 'essential',
-      optional: false,
-      cookies: ['lau-cookie-preferences', 'lau-session', 'Idam.Session', 'seen_cookie_message', '_oauth2_proxy'],
-    },
-    {
-      'category-name': 'analytics',
-      optional: true,
-      cookies: ['_ga', '_gid', 'gat'],
-    },
-    {
-      'category-name': 'apm',
-      optional: true,
-      cookies: ['dtCookie', 'dtLatC', 'dtPC', 'dtSa', 'rxVisitor', 'rxvt'],
-    },
-  ],
-});
+import {qs} from './selectors';
 
 declare global {
   interface Window {
@@ -89,4 +14,83 @@ interface DtrumApi {
   enableSessionReplay(): void;
   disable(): void;
   disableSessionReplay(): void;
+}
+
+export function initCookieManager(): void {
+  console.log('Initializing Cookie Manager V0.5');
+
+  const cookieBanner = qs('#cm-cookie-banner');
+  const cookieBannerDecision: HTMLInputElement = cookieBanner?.querySelector('.govuk-cookie-banner__decision');
+  const cookieBannerConfirmation: HTMLInputElement = cookieBanner?.querySelector('.govuk-cookie-banner__confirmation');
+
+  function cookieBannerAccept() {
+    const confirmationMessage = cookieBannerConfirmation?.querySelector('p') as HTMLInputElement;
+    confirmationMessage.innerHTML = 'You’ve accepted additional cookies. ' + confirmationMessage.innerHTML;
+  }
+
+  function cookieBannerReject() {
+    const confirmationMessage = cookieBannerConfirmation?.querySelector('p') as HTMLInputElement;
+    confirmationMessage.innerHTML = 'You’ve rejected additional cookies. ' + confirmationMessage.innerHTML;
+  }
+
+  function cookieBannerSaved() {
+    cookieBannerDecision.hidden = true;
+    cookieBannerConfirmation.hidden = false;
+  }
+
+  function preferenceFormSaved() {
+    const message = qs('.cookie-preference-success') as HTMLInputElement;
+    message.style.display = 'block';
+    document.body.scrollTop = 0; // For Safari
+    document.documentElement.scrollTop = 0; // For Chrome, Firefox, IE and Opera
+  }
+
+  // @ts-ignore
+  function cookiePreferencesUpdated(cookieStatus) {
+    const dataLayer = window.dataLayer || [];
+    const dtrum = window.dtrum;
+
+    dataLayer.push({event: 'Cookie Preferences', cookiePreferences: cookieStatus});
+
+    if (dtrum !== undefined) {
+      if (cookieStatus.apm === 'on') {
+        dtrum.enable();
+        dtrum.enableSessionReplay();
+      } else {
+        dtrum.disableSessionReplay();
+        dtrum.disable();
+      }
+    }
+  }
+
+  cookieManager.init({
+    'user-preference-cookie-name': 'lau-cookie-preferences',
+    'user-preference-saved-callback': cookiePreferencesUpdated,
+    'preference-form-id': 'cm-preference-form',
+    'preference-form-saved-callback': preferenceFormSaved,
+    'set-checkboxes-in-preference-form': true,
+    'cookie-banner-id': 'cm-cookie-banner',
+    'cookie-banner-visible-on-page-with-preference-form': false,
+    'cookie-banner-reject-callback': cookieBannerReject,
+    'cookie-banner-accept-callback': cookieBannerAccept,
+    'cookie-banner-saved-callback': cookieBannerSaved,
+    'cookie-banner-auto-hide': false,
+    'cookie-manifest': [
+      {
+        'category-name': 'essential',
+        optional: false,
+        cookies: ['lau-cookie-preferences', 'lau-session', 'Idam.Session', 'seen_cookie_message', '_oauth2_proxy'],
+      },
+      {
+        'category-name': 'analytics',
+        optional: true,
+        cookies: ['_ga', '_gid', 'gat'],
+      },
+      {
+        'category-name': 'apm',
+        optional: true,
+        cookies: ['dtCookie', 'dtLatC', 'dtPC', 'dtSa', 'rxVisitor', 'rxvt'],
+      },
+    ],
+  });
 }

--- a/src/main/assets/scss/main.scss
+++ b/src/main/assets/scss/main.scss
@@ -70,3 +70,7 @@ $color-white: #fff;
 .cookie-preference-success {
   display: none;
 }
+
+#use-cookie-manager-v1 {
+  display: none;
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2,7 +2,12 @@
 import { initAll } from 'govuk-frontend';
 
 import './assets/scss/main.scss';
-import './assets/js/cookie';
+
+import {initCookieManager} from './assets/js/cookie';
+import {initCookieManagerV1} from './assets/js/cookie-v1';
+const useCookieManagerV1 = document.getElementById('use-cookie-manager-v1').textContent === 'true';
+useCookieManagerV1 ? initCookieManagerV1() : initCookieManager();
+
 import './assets/js/flatpickr';
 import './assets/js/home';
 

--- a/src/main/modules/nunjucks/index.ts
+++ b/src/main/modules/nunjucks/index.ts
@@ -2,6 +2,7 @@ import * as path from 'path';
 import * as express from 'express';
 import * as nunjucks from 'nunjucks';
 import {numberWithCommas} from '../../util/Util';
+import {LaunchDarklyClient} from '../../components/featureToggle/LaunchDarklyClient';
 
 export class Nunjucks {
   constructor(public developmentMode: boolean) {
@@ -32,7 +33,10 @@ export class Nunjucks {
 
     env.addGlobal('nonce', app.locals.nonce);
 
-    app.use((req, res, next) => {
+    app.use(async (req, res, next) => {
+      const useCookieManagerV1 = await LaunchDarklyClient.instance.variation('cookie-manager-v-1');
+      env.addGlobal('useCookieManagerV1', useCookieManagerV1);
+
       res.locals.pagePath = req.path;
       next();
     });

--- a/src/main/views/common/template.njk
+++ b/src/main/views/common/template.njk
@@ -14,29 +14,42 @@
   <p>You can <a class="govuk-link" href="/cookies">change your cookie settings</a> at any time.</p>
 {% endset %}
 
+{% set cookieAcceptHtml %}
+  <p class="govuk-body">You’ve accepted additional cookies. You can <a class="govuk-link" href="/cookies">change your cookie settings</a> at any time.</p>
+{% endset %}
+
+{% set cookieRejectHtml %}
+  <p class="govuk-body">You’ve rejected additional cookies. You can <a class="govuk-link" href="/cookies">change your cookie settings</a> at any time.</p>
+{% endset %}
+
+{% set cookieHtml %}
+  <p class="govuk-body">We use some essential cookies to make this service work.</p>
+  <p class="govuk-body">We'd also like to use analytics cookies so we can understand how you use the service and make improvements.</p>
+{% endset %}
+
 {% block bodyStart %}
   <div class="loading-overlay">
     <div class='spinner'></div>
   </div>
-
-  <div class="global-cookie-message" id="cm-cookie-banner">
-    {{ govukCookieBanner({
-      ariaLabel: "Cookies on Log and Audit",
-      messages: [
-        {
-          headingText: "Cookies on Log and Audit",
-          html: "<p>We use some essential cookies to make this service work.</p>
-                 <p>We'd also like to use analytics cookies so we can understand how you use the service and make improvements.</p>",
-          classes: "govuk-cookie-banner__decision",
-          actions: [
+  {% if not useCookieManagerV1 %}
+    <div class="global-cookie-message" id="cm-cookie-banner">
+      {{ govukCookieBanner({
+        ariaLabel: "Cookies on Log and Audit",
+        messages: [
+          {
+            headingText: "Cookies on Log and Audit",
+            html: "<p>We use some essential cookies to make this service work.</p>
+                   <p>We'd also like to use analytics cookies so we can understand how you use the service and make improvements.</p>",
+            classes: "govuk-cookie-banner__decision",
+            actions: [
             {
               text: "Accept analytics cookies",
               type: "button",
               name: "cookies",
               value: "accept",
               attributes: {
-                'data-cm-action': 'accept'
-              }
+              'data-cm-action': 'accept'
+            }
             },
             {
               text: "Reject analytics cookies",
@@ -44,36 +57,92 @@
               name: "cookies",
               value: "reject",
               attributes: {
-                'data-cm-action': 'reject'
-              }
+              'data-cm-action': 'reject'
+            }
             },
             {
               text: "View cookies",
-              href: "#"
+              href: "/cookies"
             }
           ]
+          },
+          {
+            html: cookieConfirmationHTML,
+            role: "alert",
+            classes: "govuk-cookie-banner__confirmation",
+            hidden: true,
+            actions: [
+            {
+              text: "Hide this message",
+              type: "button",
+              attributes: {
+              'data-cm-action': 'hide'
+            }
+            }
+          ]
+          }
+        ]
+      }) }}
+    </div>
+  {% endif %}
+{% endblock %}
+
+{% block header %}
+  {% if useCookieManagerV1 %}
+    {{ govukCookieBanner({
+      classes: 'cookie-banner',
+      ariaLabel: 'Cookies on Log and Audit',
+      hidden: true,
+      messages: [
+        {
+          classes: 'cookie-banner-message',
+          headingText: 'Cookies on Log and Audit',
+          html: cookieHtml,
+          actions: [
+          {
+            classes: 'cookie-banner-accept-button',
+            text: 'Accept analytics cookies',
+            type: "button"
+          },
+          {
+            classes: 'cookie-banner-reject-button',
+            text: 'Reject analytics cookies',
+            type: "button"
+          },
+          {
+            text: 'View cookies',
+            href: "/cookies"
+          }
+        ]
         },
         {
-          html: cookieConfirmationHTML,
+          classes: 'cookie-banner-accept-message',
+          html: cookieAcceptHtml,
           role: "alert",
-          classes: "govuk-cookie-banner__confirmation",
           hidden: true,
           actions: [
           {
-            text: "Hide this message",
-            type: "button",
-            attributes: {
-              'data-cm-action': 'hide'
-            }
+            classes: 'cookie-banner-hide-button',
+            text: 'Hide this message'
+          }
+        ]
+        },
+        {
+          classes: 'cookie-banner-reject-message',
+          html: cookieRejectHtml,
+          role: "alert",
+          hidden: true,
+          actions: [
+          {
+            classes: 'cookie-banner-hide-button',
+            text: 'Hide this message'
           }
         ]
         }
       ]
     }) }}
-  </div>
-{% endblock %}
+  {% endif %}
 
-{% block header %}
   {{ govukHeader({
     homepageUrl: "/",
     serviceName: "Log and Audit",
@@ -115,4 +184,6 @@
 
   {# Load Flatpickr at end of body as this is non-critical #}
   <link rel="stylesheet" href="assets/css/flatpickr.min.css">
+
+  <div id="use-cookie-manager-v1">{{ useCookieManagerV1 }}</div>
 {% endblock %}

--- a/src/main/views/cookies/template.njk
+++ b/src/main/views/cookies/template.njk
@@ -136,7 +136,11 @@
   </section>
   <section>
     <h2 class="govuk-heading-m">{{ changeCookiesHeading }}</h2>
-    <form id="cm-preference-form" class="js-show">
+    {% if useCookieManagerV1 %}
+      <form class="cookie-preferences-form js-show">
+    {% else %}
+      <form id="cm-preference-form" class="js-show">
+    {% endif %}
       {{ govukRadios({
         classes: 'govuk-radios',
         idPrefix: 'analytics',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1311,6 +1311,11 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
+"@hmcts/cookie-manager-v1@npm:@hmcts/cookie-manager@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@hmcts/cookie-manager/-/cookie-manager-1.0.0.tgz#06a850f3854aebccf3948081e2d7071b36c60cd5"
+  integrity sha512-NLG4OY41oXp4pNKNznmpRZ7nAvmavoaOAWrRN6er+i6lVoZFY7B1yWv2R80b5n7l6cGPpT7THNoC7FPFHRaFgg==
+
 "@hmcts/cookie-manager@^0.0.5":
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/@hmcts/cookie-manager/-/cookie-manager-0.0.5.tgz#551cda51158031fc652a6631103373220d1e33a3"


### PR DESCRIPTION
### JIRA link ###

https://tools.hmcts.net/jira/browse/LAU-376

### Change description ###

Upgrade Cookie Manager to version 1 (from 0.5). This is under a feature toggle.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
