### PR TITLE
LAU-1095 call launchdarkly once

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -27,5 +27,5 @@ services:
     url: S2S_URL
 featureToggles:
   ldKey: LD_SDK_KEY
-  ft_deletedUsers: 'LAU_DELETED_USERS'
+  challengedAccessEnabled: CHALLENGED_ACCESS_ENABLED
 is_dev: IS_DEV

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -60,8 +60,8 @@ services:
 featureToggles:
   enabled: true
   ldKey: 'LD_SDK_KEY'
-  ft_deletedUsers: 'LAU_DELETED_USERS'
   ft_challengeAccess: 'lau-challenged-access'
+  challengedAccessEnabled: true
 session:
   cookieMaxAge: 30 # minutes
 is_dev: true

--- a/src/main/development.ts
+++ b/src/main/development.ts
@@ -26,6 +26,7 @@ const setUserRoleEndpoints = (app: express.Express): void => {
     refreshToken: 'refreshToken',
     expiresAt: Date.now(),
     roles: [],
+    toggleablePages: {'lau-challenged-access': config.get('featureToggles.challengedAccessEnabled')},
   };
 
   // Ensure dev user and userRoles is set

--- a/src/main/models/appRequest.ts
+++ b/src/main/models/appRequest.ts
@@ -56,4 +56,5 @@ export interface UserDetails {
   idToken: string;
   id: string;
   roles: string[];
+  toggleablePages?: {[key: string]: boolean};
 }

--- a/src/main/modules/nunjucks/index.ts
+++ b/src/main/modules/nunjucks/index.ts
@@ -4,7 +4,6 @@ import * as nunjucks from 'nunjucks';
 import {numberWithCommas} from '../../util/Util';
 import {AppRequest} from '../../models/appRequest';
 import config from 'config';
-import {FeatureToggleService} from './../../service/FeatureToggleService';
 
 export class Nunjucks {
   constructor(public developmentMode: boolean) {
@@ -33,7 +32,8 @@ export class Nunjucks {
     }
 
     app.use(async (req: AppRequest, res, next) => {
-      res.locals.challengedAccessEnabled = await FeatureToggleService.getChallengedAccessFeatureToggle();
+      const challengedAccessToggle: string = config.get('featureToggles.ft_challengeAccess');
+      res.locals.challengedAccessEnabled = req.session.user?.toggleablePages?.[challengedAccessToggle];
       res.locals.pagePath = req.path;
       next();
     });

--- a/src/main/service/AuthService.ts
+++ b/src/main/service/AuthService.ts
@@ -148,6 +148,10 @@ export class AuthService {
     const expiresAt: number = requestTimeInSeconds + Number(data.expires_in);
 
     const jwt: IdTokenJwtPayload = jwtDecode(data.id_token);
+    const challengedToggle: string = this.config.get('featureToggles.ft_challengeAccess');
+    const toggleablePages: {[key: string]: boolean} = {
+      [challengedToggle]: this.config.get('featureToggles.challengedAccessEnabled'),
+    };
 
     session.user = {
       accessToken: data.access_token,
@@ -156,7 +160,9 @@ export class AuthService {
       idToken: data.id_token,
       id: jwt.uid,
       roles: jwt.roles,
+      toggleablePages,
     };
+
     session.save(() => session.user);
     return session.user;
   }

--- a/src/main/service/FeatureToggleService.ts
+++ b/src/main/service/FeatureToggleService.ts
@@ -2,11 +2,6 @@ import config from 'config';
 import {LaunchDarklyClient} from '../components/featureToggle/LaunchDarklyClient';
 
 export class FeatureToggleService{
-  public static async getDeletedUsersFeatureToggle(): Promise<void> {
-    const deletedUsersFt = String(config.get('featureToggles.ft_deletedUsers'));
-    const deletedUsersFtValue = await LaunchDarklyClient.instance.variation(deletedUsersFt, false);
-    return deletedUsersFtValue;
-  }
 
   public static async getChallengedAccessFeatureToggle(): Promise<void> {
     const isDevelopment = Boolean(config.get('is_dev'));

--- a/src/test/unit/components/LaunchDarklyClient.test.ts
+++ b/src/test/unit/components/LaunchDarklyClient.test.ts
@@ -14,6 +14,7 @@ describe('LaunchDarklyClient', () => {
   it('initialises the client', async () => {
     expect(LaunchDarklyClient.instance).toBeDefined();
   });
+
   it('successfully calls and returns truthy variation value', async () => {
     // Simulate LDClient variation method returning true
     jest.spyOn(LaunchDarklyClient.instance, 'variation').mockResolvedValue(true);
@@ -21,6 +22,7 @@ describe('LaunchDarklyClient', () => {
     const testFeature = await LaunchDarklyClient.instance.variation('test', true);
     expect(testFeature).toBeTruthy();
   });
+
   it('successfully calls and returns falsy variation value', async () => {
     // Simulate LDClient variation method returning false
     jest.spyOn(LaunchDarklyClient.instance, 'variation').mockResolvedValue(false);
@@ -28,6 +30,7 @@ describe('LaunchDarklyClient', () => {
     const testFeature = await LaunchDarklyClient.instance.variation('test', false);
     expect(testFeature).toBeFalsy();
   });
+
   it('successfully calls and returns true variation value when enviornment is development', async () => {
     (config.get as jest.Mock).mockImplementation((key: string) => {
       if (key === 'is_dev') return 'true';
@@ -40,6 +43,7 @@ describe('LaunchDarklyClient', () => {
     const result = await FeatureToggleService.getChallengedAccessFeatureToggle();
     expect(result).toBeTruthy();
   });
+
   it('successfully calls and returns false variation value when enviornment is not development', async () => {
     (config.get as jest.Mock).mockImplementation((key: string) => {
       if (key === 'is_dev') return 'false';
@@ -51,6 +55,5 @@ describe('LaunchDarklyClient', () => {
 
     const result = await FeatureToggleService.getChallengedAccessFeatureToggle();
     expect(result).toBeFalsy();
-  
   });
 });

--- a/src/test/unit/service/AuthService.test.ts
+++ b/src/test/unit/service/AuthService.test.ts
@@ -104,6 +104,7 @@ describe('AuthService', () => {
         idToken: serviceToken,
         id: 'lau_id',
         roles: ['cft-audit-investigator'],
+        toggleablePages: {'lau-challenged-access': true},
       };
       expect(userDetails).toStrictEqual(expectedUser);
 
@@ -145,6 +146,7 @@ describe('AuthService', () => {
         idToken: serviceToken,
         id: 'lau_id',
         roles: ['cft-audit-investigator'],
+        toggleablePages: {'lau-challenged-access': true},
       };
       expect(userDetails).toStrictEqual(expectedUser);
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
LAU-1095


### Change description ###
Call launchdarkly on login once, rather than with each navigation click

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```