### PR TITLE
Reorder java repos

### DIFF
--- a/src/test/java/build.gradle
+++ b/src/test/java/build.gradle
@@ -8,10 +8,10 @@ targetCompatibility = '21'
 // tag::repositories[]
 repositories {
     mavenLocal()
-    mavenCentral()
     maven {
       url = 'https://pkgs.dev.azure.com/hmcts/Artifacts/_packaging/hmcts-lib/maven/v1'
     }
+    mavenCentral()
 }
 // end::repositories[]
 


### PR DESCRIPTION
### Change description ###
Reorder java repos for fortify, so we try from azure first and then mavencentral to not be impacted by rate limiter


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```