### PR TITLE
LAU-1476 remove old redis cache

### DIFF
--- a/charts/lau-frontend/Chart.yaml
+++ b/charts/lau-frontend/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for Log and Audit Frontend App
 name: lau-frontend
 home: https://github.com/hmcts/lau-frontend
-version: 0.2.20
+version: 0.2.21
 dependencies:
   - name: nodejs
     version: 3.2.1

--- a/charts/lau-frontend/values.yaml
+++ b/charts/lau-frontend/values.yaml
@@ -10,9 +10,6 @@ nodejs:
     REFORM_SERVICE_NAME: lau-frontend
     REFORM_ENVIRONMENT: '{{ .Values.global.environment }}'
     USE_REDIS: true
-    REDIS_USE_TLS: true
-    REDIS_PORT: 6380
-    REDIS_HOST: lau-frontend-session-storage-{{ .Values.global.environment }}.redis.cache.windows.net
     LAU_CASE_BACKEND_URL: http://lau-case-backend-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
     LAU_IDAM_BACKEND_URL: http://lau-idam-backend-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
     LAU_EUD_BACKEND_URL: http://lau-eud-backend-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
@@ -37,7 +34,6 @@ nodejs:
       secrets:
         - managed-redis-connection-string
         - app-insights-connection-string
-        - frontend-redis-access-key
         - idam-client-secret
         - s2s-secret
         - session-secret

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -1,10 +1,6 @@
 ---
 testUrl: TEST_URL
 redis:
-  host: REDIS_HOST
-  port: REDIS_PORT
-  password: REDIS_PASSWORD
-  useTLS: REDIS_USE_TLS
   enabled: USE_REDIS
   secret: REDIS_SECRET
 pagination:

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -12,10 +12,7 @@ pagination:
   maxPerPage: 100
   maxTotal: 10000
 redis:
-  host: 'localhost'
-  port: 6379
-  password: 'dummy_password'
-  useTLS: 'false'
+  connectionString: 'redis://:dummy_password@localhost:6379'
   enabled: false
   proxy: true
   resave: false

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -13,22 +13,6 @@ data "azurerm_subnet" "core_infra_redis_subnet" {
   resource_group_name  = "core-infra-${var.env}"
 }
 
-
-module "lau-frontend-session-storage" {
-  source                        = "git@github.com:hmcts/cnp-module-redis?ref=4.x"
-  product                       = "${var.product}-${var.component}-session-storage"
-  location                      = var.location
-  env                           = var.env
-  common_tags                   = var.common_tags
-  redis_version                 = "6"
-  business_area                 = "cft"
-  private_endpoint_enabled      = true
-  public_network_access_enabled = false
-  sku_name                      = var.sku_name
-  family                        = var.family
-  capacity                      = var.capacity
-}
-
 module "lau-frontend-managed-redis" {
   source      = "git@github.com:hmcts/terraform-module-azure-managed-redis?ref=main"
   product     = var.product
@@ -50,12 +34,6 @@ module "lau-frontend-managed-redis" {
 data "azurerm_key_vault" "key_vault" {
   name                = local.vaultName
   resource_group_name = local.vaultName
-}
-
-resource "azurerm_key_vault_secret" "redis_access_key" {
-  name         = "${var.component}-redis-access-key"
-  value        = module.lau-frontend-session-storage.access_key
-  key_vault_id = data.azurerm_key_vault.key_vault.id
 }
 
 resource "azurerm_key_vault_secret" "managed_redis_connection_string" {

--- a/infrastructure/prod.tfvars
+++ b/infrastructure/prod.tfvars
@@ -1,3 +1,1 @@
-sku_name = "Premium"
-family   = "P"
-capacity = "1"
+managed_sku_name = "Balanced_B1"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -28,24 +28,10 @@ variable "appinsights_instrumentation_key" {
 variable "common_tags" {
   type = map(string)
 }
-variable "family" {
-  default     = "C"
-  description = "The SKU family/pricing group to use. Valid values are `C` (for Basic/Standard SKU family) and `P` (for Premium). Use P for higher availability, but beware it costs a lot more."
-}
-
-variable "sku_name" {
-  default     = "Basic"
-  description = "The SKU of Redis to use. Possible values are `Basic`, `Standard` and `Premium`."
-}
 
 variable "managed_sku_name" {
-  default     = "Balanced_B1"
+  default     = "Balanced_B0"
   description = "The SKU of Redis to use. E.g. Balanced_B1, MemoryOptimized_M10, FlashOptimized_A250"
-}
-
-variable "capacity" {
-  default     = "1"
-  description = "The size of the Redis cache to deploy. Valid values are 1, 2, 3, 4, 5"
 }
 
 variable "session_secret_rotation" {

--- a/src/main/modules/properties-volume/index.ts
+++ b/src/main/modules/properties-volume/index.ts
@@ -7,7 +7,6 @@ export class PropertiesVolume {
     if (env !== 'development') {
       propertiesVolume.addTo(config);
       PropertiesVolume.setSecret('secrets.lau.app-insights-connection-string', 'appInsights.connectionString');
-      PropertiesVolume.setSecret('secrets.lau.frontend-redis-access-key', 'redis.password');
       PropertiesVolume.setSecret('secrets.lau.idam-client-secret', 'services.idam-api.clientSecret');
       PropertiesVolume.setSecret('secrets.lau.s2s-secret', 'services.s2s.lauSecret');
       PropertiesVolume.setSecret('secrets.lau.session-secret', 'session.secret');


### PR DESCRIPTION
### JIRA link (if applicable) ###
[LAU-1476](https://tools.hmcts.net/jira/browse/LAU-1476)

### Change description ###
After moving to managed redis, old redis cache is no longer needed and can be removed.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```